### PR TITLE
Add card-image component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4904,6 +4904,11 @@
       "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
       "dev": true
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "~12.2.0",
     "@angular/platform-browser-dynamic": "~12.2.0",
     "@angular/router": "~12.2.0",
+    "font-awesome": "^4.7.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,15 +1,24 @@
+header {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+  background-color: #fdfdfd;
+}
+
+header h2 {
+  font-size: 1.2rem;
+  color: #666666;
+  margin: 0;
+  padding: 0.75rem 6rem;
+  border-bottom: 1px solid #cccccc;
+  box-shadow: 0px 2px 8px #ddd;
+}
+
 .container {
   display: flex;
   flex-direction: column;
   margin: 0 5rem;
   padding: 0;
-}
-
-.container header {
-  font-size: 1rem;
-  color: #666666;
-  padding: 0 1rem;
-  margin: 0;
 }
 
 .wrapper {
@@ -29,4 +38,10 @@
   width: 90%;
   flex: 9 200px;
   padding: 1rem;
+}
+
+.content .category {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,15 +1,18 @@
+<header>
+  <h2>Moviemania</h2>
+</header>
 <div class="container">
-  <header>
-    <h2>Moviemania</h2>
-  </header>
   <div class="wrapper">
     <aside class="sidebar">
-      <mm-side-bar
-      [sideBarMenu]="sideBarMenu"
-      ></mm-side-bar>
+      <mm-side-bar [sideBarMenu]="sideBarMenu"></mm-side-bar>
     </aside>
     <main class="content">
       <h2>Content</h2>
+      <div class="category">
+        <div *ngFor="let x of movies">
+          <mm-card-image [movie]="x"></mm-card-image>
+        </div>
+      </div>
     </main>
   </div>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { Movie } from './shared/card-image/card-image';
 
 import { SideBarMenu } from './shared/side-bar/side-bar';
 
@@ -29,6 +30,177 @@ export class AppComponent {
     {
       title: 'Upcoming',
       tag: 'upcoming',
+    },
+  ];
+  movie: Movie = {
+    backdrop_path: "/lNyLSOKMMeUPr1RsL4KcRuIXwHt.jpg",
+    id: 580489,
+    original_language: "en",
+    original_title: "Venom: Let There Be Carnage",
+    overview: "After finding a host body in investigative reporter Eddie Brock, the alien symbiote must face a new enemy, Carnage, the alter ego of serial killer Cletus Kasady.",
+    popularity: 4293.383,
+    poster_path: "/rjkmN1dniUHVYAtwuV3Tji7FsDO.jpg",
+    release_date: "2021-09-30",
+    title: "Venom: Let There Be Carnage",
+    video: false,
+    vote_average: 6.8,
+    vote_count: 1798
+    }
+
+  movies: Movie[] = [
+    {
+    "backdrop_path": "/lNyLSOKMMeUPr1RsL4KcRuIXwHt.jpg",
+    "id": 580489,
+    "original_language": "en",
+    "original_title": "Venom: Let There Be Carnage",
+    "overview": "After finding a host body in investigative reporter Eddie Brock, the alien symbiote must face a new enemy, Carnage, the alter ego of serial killer Cletus Kasady.",
+    "popularity": 4293.383,
+    "poster_path": "/rjkmN1dniUHVYAtwuV3Tji7FsDO.jpg",
+    "release_date": "2021-09-30",
+    "title": "Venom: Let There Be Carnage",
+    "video": false,
+    "vote_average": 6.8,
+    "vote_count": 1798
+    },
+    {
+    "backdrop_path": "/eeijXm3553xvuFbkPFkDG6CLCbQ.jpg",
+    "id": 438631,
+    "original_language": "en",
+    "original_title": "Dune",
+    "overview": "Paul Atreides, a brilliant and gifted young man born into a great destiny beyond his understanding, must travel to the most dangerous planet in the universe to ensure the future of his family and his people. As malevolent forces explode into conflict over the planet's exclusive supply of the most precious resource in existence-a commodity capable of unlocking humanity's greatest potential-only those who can conquer their fear will survive.",
+    "popularity": 2264.439,
+    "poster_path": "/d5NXSklXo0qyIYkgV94XAgMIckC.jpg",
+    "release_date": "2021-09-15",
+    "title": "Dune",
+    "video": false,
+    "vote_average": 8,
+    "vote_count": 3716
+    },
+    {
+    "backdrop_path": "/fzKWwcaam9QSTaMSJlORuSojxio.jpg",
+    "id": 524434,
+    "original_language": "en",
+    "original_title": "Eternals",
+    "overview": "The Eternals are a team of ancient aliens who have been living on Earth in secret for thousands of years. When an unexpected tragedy forces them out of the shadows, they are forced to reunite against mankind’s most ancient enemy, the Deviants.",
+    "popularity": 2462.242,
+    "poster_path": "/6AdXwFTRTAzggD2QUTt5B7JFGKL.jpg",
+    "release_date": "2021-11-03",
+    "title": "Eternals",
+    "video": false,
+    "vote_average": 7.1,
+    "vote_count": 739
+    },
+    {
+    "backdrop_path": "/mu8RKavbv7Ml48twHQ6XVk7zw8e.jpg",
+    "id": 796499,
+    "original_language": "en",
+    "original_title": "Army of Thieves",
+    "overview": "A mysterious woman recruits bank teller Ludwig Dieter to lead a group of aspiring thieves on a top-secret heist during the early stages of the zombie apocalypse.",
+    "popularity": 2654.451,
+    "poster_path": "/j04Oepj3LGTWSb1ltXm0pcy50Xq.jpg",
+    "release_date": "2021-10-27",
+    "title": "Army of Thieves",
+    "video": false,
+    "vote_average": 6.9,
+    "vote_count": 590
+    },
+    {
+    "backdrop_path": "/cinER0ESG0eJ49kXlExM0MEWGxW.jpg",
+    "id": 566525,
+    "original_language": "en",
+    "original_title": "Shang-Chi and the Legend of the Ten Rings",
+    "overview": "Shang-Chi must confront the past he thought he left behind when he is drawn into the web of the mysterious Ten Rings organization.",
+    "popularity": 2601.273,
+    "poster_path": "/xeItgLK9qcafxbd8kYgv7XnMEog.jpg",
+    "release_date": "2021-09-01",
+    "title": "Shang-Chi and the Legend of the Ten Rings",
+    "video": false,
+    "vote_average": 7.8,
+    "vote_count": 1726
+    },
+    {
+    "backdrop_path": "/8Y43POKjjKDGI9MH89NW0NAzzp8.jpg",
+    "id": 550988,
+    "original_language": "en",
+    "original_title": "Free Guy",
+    "overview": "A bank teller called Guy realizes he is a background character in an open world video game called Free City that will soon go offline.",
+    "popularity": 1576.431,
+    "poster_path": "/xmbU4JTUm8rsdtn7Y3Fcm30GpeT.jpg",
+    "release_date": "2021-08-11",
+    "title": "Free Guy",
+    "video": false,
+    "vote_average": 7.8,
+    "vote_count": 3536
+    },
+    {
+    "backdrop_path": "/u5Fp9GBy9W8fqkuGfLBuuoJf57Z.jpg",
+    "id": 370172,
+    "original_language": "en",
+    "original_title": "No Time to Die",
+    "overview": "Bond has left active service and is enjoying a tranquil life in Jamaica. His peace is short-lived when his old friend Felix Leiter from the CIA turns up asking for help. The mission to rescue a kidnapped scientist turns out to be far more treacherous than expected, leading Bond onto the trail of a mysterious villain armed with dangerous new technology.",
+    "popularity": 1184.338,
+    "poster_path": "/iUgygt3fscRoKWCV1d0C7FbM9TP.jpg",
+    "release_date": "2021-09-29",
+    "title": "No Time to Die",
+    "video": false,
+    "vote_average": 7.5,
+    "vote_count": 1399
+    },
+    {
+    "backdrop_path": "/hugKriLPeBm3lErSCQiFOgQzpkC.jpg",
+    "id": 574060,
+    "original_language": "en",
+    "original_title": "Gunpowder Milkshake",
+    "overview": "In her turbulent life as a professional assassin, Sam has no choice but to go rogue to save the life of an innocent 8-year-old girl in the middle of the gang war she has unleashed.",
+    "popularity": 1094.568,
+    "poster_path": "/5AaKulwpUtkscAokKWtLenGTfVS.jpg",
+    "release_date": "2021-07-14",
+    "title": "Gunpowder Milkshake",
+    "video": false,
+    "vote_average": 6.5,
+    "vote_count": 350
+    },
+    {
+    "backdrop_path": "/oE6bhqqVFyIECtBzqIuvh6JdaB5.jpg",
+    "id": 522402,
+    "original_language": "en",
+    "original_title": "Finch",
+    "overview": "On a post-apocalyptic Earth, a robot, built to protect the life of his dying creator's beloved dog, learns about life, love, friendship, and what it means to be human.",
+    "popularity": 1077.773,
+    "poster_path": "/jKuDyqx7jrjiR9cDzB5pxzhJAdv.jpg",
+    "release_date": "2021-11-04",
+    "title": "Finch",
+    "video": false,
+    "vote_average": 8.1,
+    "vote_count": 639
+    },
+    {
+    "backdrop_path": "/VuukZLgaCrho2Ar8Scl9HtV3yD.jpg",
+    "id": 335983,
+    "original_language": "en",
+    "original_title": "Venom",
+    "overview": "Investigative journalist Eddie Brock attempts a comeback following a scandal, but accidentally becomes the host of Venom, a violent, super powerful alien symbiote. Soon, he must rely on his newfound powers to protect the world from a shadowy organization looking for a symbiote of their own.",
+    "popularity": 953.538,
+    "poster_path": "/2uNW4WbgBXL25BAbXGLnLqX71Sw.jpg",
+    "release_date": "2018-09-28",
+    "title": "Venom",
+    "video": false,
+    "vote_average": 6.8,
+    "vote_count": 12144
+    },
+    {
+    "backdrop_path": "/6xCOWFIb1Za7jeP6rqw7SfPgkNX.jpg",
+    "id": 768449,
+    "original_language": "en",
+    "original_title": "American Badger",
+    "overview": "A seemingly cold-blooded hitman is assigned to befriend a call girl, but all hell breaks loose when he is assigned to kill her.",
+    "popularity": 943.442,
+    "poster_path": "/8mO2ZTTOnLnaEQd1sNZAE2XBoOg.jpg",
+    "release_date": "2021-03-05",
+    "title": "American Badger",
+    "video": false,
+    "vote_average": 6.3,
+    "vote_count": 14
     },
   ];
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,11 +3,15 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { AppComponent } from './app.component';
 import { SideBarComponent } from './shared/side-bar/side-bar.component';
+import { CardImageComponent } from './shared/card-image/card-image.component';
+import { ConvertToEllipsesPipe } from './shared/convert-to-ellipses-pipes/convert-to-ellipses.pipe';
 
 @NgModule({
   declarations: [
     AppComponent,
-    SideBarComponent
+    SideBarComponent,
+    CardImageComponent,
+    ConvertToEllipsesPipe,
   ],
   imports: [
     BrowserModule

--- a/src/app/shared/card-image/card-image.component.css
+++ b/src/app/shared/card-image/card-image.component.css
@@ -1,0 +1,28 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  margin: 1rem;
+}
+
+.card-image img {
+  width: 200px;
+  height: auto;
+}
+
+.card-title {
+  font-size: 1rem;
+  color: #666666;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 0.25rem;
+}
+
+.card-footer{
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: #666666;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/app/shared/card-image/card-image.component.html
+++ b/src/app/shared/card-image/card-image.component.html
@@ -1,0 +1,15 @@
+<div class="card">
+  <div class="card-image">
+    <img
+      src="https://image.tmdb.org/t/p/original{{ movie.poster_path }}"
+      alt="movie poster"
+    />
+  </div>
+  <div class="card-body">
+    <h3 class="card-title"><span>{{ movie.title | convertToEllipses }}</span> <span>({{ releaseDate.getFullYear()}})</span></h3>
+  </div>
+  <div class="card-footer">
+    <div><span class="fa fa-star" *ngFor="let index of ratingSize"></span></div>
+    {{ movie.vote_count }} votes
+  </div>
+</div>

--- a/src/app/shared/card-image/card-image.component.spec.ts
+++ b/src/app/shared/card-image/card-image.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardImageComponent } from './card-image.component';
+
+describe('CardImageComponent', () => {
+  let component: CardImageComponent;
+  let fixture: ComponentFixture<CardImageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CardImageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardImageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/card-image/card-image.component.ts
+++ b/src/app/shared/card-image/card-image.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+import { Movie } from './card-image';
+
+@Component({
+  selector: 'mm-card-image',
+  templateUrl: './card-image.component.html',
+  styleUrls: ['./card-image.component.css']
+})
+export class CardImageComponent implements OnInit {
+  @Input() movie!: Movie;
+  ratingSize!: number[];
+  releaseDate!: Date;
+
+  constructor() { }
+
+  ngOnInit(): void {
+    this.ratingSize = [...Array(Math.round(this.movie.vote_average/2)).keys()];
+    this.releaseDate = new Date(this.movie.release_date);
+  }
+
+}

--- a/src/app/shared/card-image/card-image.ts
+++ b/src/app/shared/card-image/card-image.ts
@@ -1,0 +1,14 @@
+export interface Movie {
+    backdrop_path: string;
+    id: number;
+    original_language: string;
+    original_title: string;
+    overview: string;
+    popularity: number;
+    poster_path: string;
+    release_date: string;
+    title: string;
+    video:  boolean;
+    vote_average: number;
+    vote_count: number;
+}

--- a/src/app/shared/convert-to-ellipses-pipes/convert-to-ellipses.pipe.spec.ts
+++ b/src/app/shared/convert-to-ellipses-pipes/convert-to-ellipses.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { ConvertToEllipsesPipe } from './convert-to-ellipses.pipe';
+
+describe('ConvertToEllipsesPipe', () => {
+  it('create an instance', () => {
+    const pipe = new ConvertToEllipsesPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/convert-to-ellipses-pipes/convert-to-ellipses.pipe.ts
+++ b/src/app/shared/convert-to-ellipses-pipes/convert-to-ellipses.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'convertToEllipses'
+})
+export class ConvertToEllipsesPipe implements PipeTransform {
+
+  transform(value: string): string {
+    return value.length > 17 ? `${value.substr(0, 17)}...` : value;
+  }
+
+}

--- a/src/app/shared/side-bar/side-bar.component.css
+++ b/src/app/shared/side-bar/side-bar.component.css
@@ -10,6 +10,10 @@
   padding: 0;
 }
 
+.nav-item:nth-child(1) {
+  margin-top: 1rem;
+}
+
 .nav-item {
   margin-bottom: 1rem;
   font-size: 1.1rem;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
+@import "~font-awesome/css/font-awesome.min.css";
+
+*{
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
#### What does this MR do?
This MR adds card-image component

#### Description of Task to be completed?
- generate card-image component
- generate convert-to-ellipses-pipe
- set global margins and paddings to zero
- make app header sticky-top

#### How should this be manually tested?
- Clone the repo
- Install dependencies `npm install`
- Checkout to `ch-add-card-image-component`
- run `npm start`
- visit POST `localhost:4200`

#### Any background context you want to provide?
- Install nodejs

#### What are the relevant project issue?
N/A

#### Screenshots (if appropriate)
<img width="1440" alt="Screenshot 2021-11-15 at 20 40 41" src="https://user-images.githubusercontent.com/31358867/141843618-0968f5a1-1c53-4730-9d76-994535cb68f9.png">


#### Questions:
